### PR TITLE
Updating index.html with SF-EastBay CoffeeOpsInfo

### DIFF
--- a/_site/index.html
+++ b/_site/index.html
@@ -45,6 +45,9 @@ Coordinators:
 <li><p><a href="http://www.meetup.com/ladevops/events/218067202/">LA DevOps Thursdays</a>
 Coordinator:
 <a href="https://twitter.com/solarce">@solarce</a></p></li>
+<li><p><a href="https://www.google.com/calendar/embed?src=got3og7boqaqns50gs82s2u100%40group.calendar.google.com&ctz=America/Los_Angeles">SF and East Bay CoffeeOps</a>
+Coordinator:
+<a href="http://twitter.com/jamfish728">@jamfish728</a></p></li>
 <li><p>Boston/Cambridge Coordinator:<a href="https://twitter.com/petecheslock">@petecheslock</a></p></li>
 <li><p>Melbourne
 Coordinator:

--- a/_site/index.html
+++ b/_site/index.html
@@ -45,7 +45,10 @@ Coordinators:
 <li><p><a href="http://www.meetup.com/ladevops/events/218067202/">LA DevOps Thursdays</a>
 Coordinator:
 <a href="https://twitter.com/solarce">@solarce</a></p></li>
-<li><p><a href="https://www.google.com/calendar/embed?src=got3og7boqaqns50gs82s2u100%40group.calendar.google.com&ctz=America/Los_Angeles">SF and East Bay CoffeeOps</a>
+<li><p><a href="https://www.google.com/calendar/embed?src=got3og7boqaqns50gs82s2u100%40group.calendar.google.com&ctz=America/Los_Angeles">San Francisco CoffeeOps</a>
+Coordinator:
+<a href="http://twitter.com/jamfish728">@jamfish728</a></p></li>
+<li><p><a href="https://www.google.com/calendar/embed?src=got3og7boqaqns50gs82s2u100%40group.calendar.google.com&ctz=America/Los_Angeles">East Bay CoffeeOps</a>
 Coordinator:
 <a href="http://twitter.com/jamfish728">@jamfish728</a></p></li>
 <li><p>Boston/Cambridge Coordinator:<a href="https://twitter.com/petecheslock">@petecheslock</a></p></li>

--- a/index.md
+++ b/index.md
@@ -31,7 +31,7 @@ Coffeeops aims to bring on the Age of Delightenment fueled by coffee (tea or coc
     [ @nekodojo ](https://twitter.com/nekodojo)
     [ @parabuzzle ](https://twitter.com/parabuzzle)
 
-* East Bay, California Coordinator: [@jamfish728](https://twitter.com/jamfish728)
+* East Bay and San Francisco, California Coordinator: [@jamfish728](https://twitter.com/jamfish728)
 
 * [LA DevOps Thursdays](http://www.meetup.com/ladevops/events/218067202/)
   Coordinator:


### PR DESCRIPTION
Including the Calendar link for events as well as Organizer for SF-EastBay CoffeeOps.
